### PR TITLE
pin the colors package version to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-as-promised": "^7.1.0",
-    "colors": "^1.3.0",
+    "colors": "1.4.0",
     "eslint": "^6.4.0",
     "jszip": "^3.2.0",
     "mocha": "^6.2.0",


### PR DESCRIPTION
Use the latest good version of colors - see https://github.com/Marak/colors.js/issues/285